### PR TITLE
feat: improve types

### DIFF
--- a/src/context/auth0-context.tsx
+++ b/src/context/auth0-context.tsx
@@ -135,7 +135,7 @@ export interface IAuth0Context {
     /**
      * This method allows you to render a component while the user is  being redirected to Auth0.
      */
-    onRedirecting?: () => React.Component;
+    onRedirecting?: () => React.ReactElement<any> | null;
 
     /**
      * This method will be called after the user has been signed in, allowing you to redirect them to some page.

--- a/src/context/auth0-provider.tsx
+++ b/src/context/auth0-provider.tsx
@@ -31,7 +31,7 @@ export interface Auth0ProviderOptions {
   /**
    * This method allows you to render a component while the user is  being redirected to Auth0.
    */
-  onRedirecting?: () => React.Component;
+  onRedirecting?: () => React.ReactElement<any> | null;
 
   /**
    * This method will be called after the user has been signed in, allowing you to redirect them to some page.

--- a/src/wrappers/with-auth.tsx
+++ b/src/wrappers/with-auth.tsx
@@ -1,18 +1,17 @@
 import React from 'react';
-
 import useAuth from '../hooks/use-auth';
 import { AccessTokenRequestOptions } from '../context/auth0-context';
-import withWrapper, { IComponentProps } from '../utils/with-wrapper';
+import withWrapper from '../utils/with-wrapper';
 
-export default function withAuth(
-  ChildComponent: React.ComponentClass<any>,
+export default function withAuth<TChildProps>(
+  ChildComponent: React.ComponentType<TChildProps>,
   options?: AccessTokenRequestOptions
-): React.ReactNode {
-  return withWrapper<IComponentProps>(ChildComponent, 'withAuth', ({ ...props }) => {
+): React.ComponentType<TChildProps> {
+  return withWrapper(ChildComponent, 'withAuth', ({ ...props }) => {
     const auth = useAuth(options);
 
     return (
-      <ChildComponent {...props} auth={auth} />
+      <ChildComponent {...props as TChildProps} auth={auth} />
     );
   });
 }


### PR DESCRIPTION
withLoginRequired and withAuth weren't typed properly. Their parameters
required ClassComponents. Using FunctionalComponents weren't possible
previously. This commit changes their parameters to ComponentType. It accepts
class components and function components.

Returned values are typed properly too. withAuth returns same component type
that was passed as a param. withLoginRequired adds optional path property.