### PR TITLE
Use `console.error` if `onLoginError` is not provided

### DIFF
--- a/src/context/user-provider.tsx
+++ b/src/context/user-provider.tsx
@@ -73,6 +73,8 @@ export default function UserProvider({ children }: UserProviderOptions): JSX.Ele
           // Call a custom error handler if available.
           if (handlers.onLoginError) {
             handlers.onLoginError(err);
+          } else {
+            console.error(err);
           }
         }
       }


### PR DESCRIPTION
Resolves #28 